### PR TITLE
Changing step 1 - adding in Partners

### DIFF
--- a/TokenSale.html
+++ b/TokenSale.html
@@ -37,10 +37,10 @@
            </p>
            <form ng-cloak>
               <md-radio-group ng-model="account.currencyType" >
-                 <md-radio-button value="ETH">ETH (ether) (recommended) </md-radio-button>
-                 <md-radio-button value="BTC">BTC (bitcoin)</md-radio-button>
-                 <md-radio-button value="FIAT">USD/EUR/GPB</md-radio-button>
-                 <md-radio-button value="COINS">XRP, LTC, MAID, DASH, DOGE, XMR, BTS and all other Digital Currencies</md-radio-button>
+                 <md-radio-button value="ETH">ETH (Direct - recommended) </md-radio-button>
+                 <md-radio-button value="BTC">BTC (Gatecoin)</md-radio-button>
+                 <md-radio-button value="FIAT">USD/EUR/GPB (Bity)</md-radio-button>
+                 <md-radio-button value="COINS">Other Digital Currencies (ShapeShift)</md-radio-button>
               </md-radio-group>
            </form>
         </md-content>


### PR DESCRIPTION
If you own ETH you might not know that its called ether, there is no one who owns ether and doesn't know ETH is it's symbol... It looks much better to me this way. Also ShapeShift only does some Cryptos, not all and we weren't explicitly calling out what CHF is or those other crypto ticker symbols which are the acronyms that would actually confuse people.